### PR TITLE
[2022.07.28] HistoryStoryboard 오토레이아웃 수정

### DIFF
--- a/TalTal/TalTal.xcodeproj/project.pbxproj
+++ b/TalTal/TalTal.xcodeproj/project.pbxproj
@@ -20,7 +20,7 @@
 		70ACFB04288E7B20006C23E5 /* MissionQuestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70ACFB03288E7B20006C23E5 /* MissionQuestView.swift */; };
 		70ACFB07288E7B67006C23E5 /* MissionQuestView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 70ACFB06288E7B67006C23E5 /* MissionQuestView.xib */; };
 		70ACFB0A288E7C07006C23E5 /* UIViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70ACFB09288E7C07006C23E5 /* UIViewExtension.swift */; };
-		70DEFD9A28912CD300F6C0F8 /* MissionAessts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70DEFD9928912CD300F6C0F8 /* MissionAessts.swift */; };
+		70DEFD9A28912CD300F6C0F8 /* MissionAssets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70DEFD9928912CD300F6C0F8 /* MissionAssets.swift */; };
 		B25B12BB28894B960013EEC6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B25B12BA28894B960013EEC6 /* AppDelegate.swift */; };
 		B25B12BD28894B960013EEC6 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B25B12BC28894B960013EEC6 /* SceneDelegate.swift */; };
 		B25B12BF28894B960013EEC6 /* TabbarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B25B12BE28894B960013EEC6 /* TabbarViewController.swift */; };
@@ -47,7 +47,7 @@
 		70ACFB03288E7B20006C23E5 /* MissionQuestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionQuestView.swift; sourceTree = "<group>"; };
 		70ACFB06288E7B67006C23E5 /* MissionQuestView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MissionQuestView.xib; sourceTree = "<group>"; };
 		70ACFB09288E7C07006C23E5 /* UIViewExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewExtension.swift; sourceTree = "<group>"; };
-		70DEFD9928912CD300F6C0F8 /* MissionAessts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionAessts.swift; sourceTree = "<group>"; };
+		70DEFD9928912CD300F6C0F8 /* MissionAssets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionAssets.swift; sourceTree = "<group>"; };
 		B25B12B728894B960013EEC6 /* TalTal.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TalTal.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B25B12BA28894B960013EEC6 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		B25B12BC28894B960013EEC6 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -112,7 +112,7 @@
 			children = (
 				70AAD5E4288DD37B001CEE5F /* MissionViewController.swift */,
 				70ACFB03288E7B20006C23E5 /* MissionQuestView.swift */,
-				70DEFD9928912CD300F6C0F8 /* MissionAessts.swift */,
+				70DEFD9928912CD300F6C0F8 /* MissionAssets.swift */,
 			);
 			path = Mission;
 			sourceTree = "<group>";
@@ -264,7 +264,7 @@
 				70AAD5F0288DDE63001CEE5F /* ShowReflectionViewController.swift in Sources */,
 				FBDA911B288EEFE600D126E6 /* MissionDataManager.swift in Sources */,
 				B25B12BF28894B960013EEC6 /* TabbarViewController.swift in Sources */,
-				70DEFD9A28912CD300F6C0F8 /* MissionAessts.swift in Sources */,
+				70DEFD9A28912CD300F6C0F8 /* MissionAssets.swift in Sources */,
 				FBDA9121288EF31500D126E6 /* HistoryCell.swift in Sources */,
 				B25B12C528894B960013EEC6 /* TalTal.xcdatamodeld in Sources */,
 				70AAD5E7288DD397001CEE5F /* MissionClearViewController.swift in Sources */,

--- a/TalTal/TalTal/Controllers/Mission/MissionAssets.swift
+++ b/TalTal/TalTal/Controllers/Mission/MissionAssets.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-struct MissionAessts{
+struct MissionAssets{
     // CornerRadius의 기본값을 설정해두었습니다.
     let viewCornerRadius = 20.0
     

--- a/TalTal/TalTal/Controllers/Mission/MissionViewController.swift
+++ b/TalTal/TalTal/Controllers/Mission/MissionViewController.swift
@@ -8,7 +8,7 @@
 import UIKit
 @IBDesignable
 final class MissionViewController: UIViewController {
-    let missionAessts = MissionAessts()
+    let missionAessts = MissionAssets()
     // MissionAessts()를 사용하기위해 선언
     
     //스토리보드에 있는 객체들을 연결

--- a/TalTal/TalTal/StoryBoard/History.storyboard
+++ b/TalTal/TalTal/StoryBoard/History.storyboard
@@ -17,97 +17,104 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="기록" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2DG-cM-HgV">
-                                <rect key="frame" x="16" y="88" width="343" height="37"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dXH-Tq-Ujw" userLabel="404TopLable">
+                                <rect key="frame" x="16" y="44" width="343" height="54.666666666666657"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="ege-A2-Oop">
-                                <rect key="frame" x="16" y="145" width="343" height="32"/>
-                                <segments>
-                                    <segment title="일간 미션"/>
-                                    <segment title="주간 미션"/>
-                                </segments>
-                                <color key="selectedSegmentTintColor" name="PointPink"/>
-                                <connections>
-                                    <action selector="switchMissionType:" destination="Y6W-OH-hqX" eventType="valueChanged" id="0zl-W0-TaS"/>
-                                </connections>
-                            </segmentedControl>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="TMn-Q6-S1c">
-                                <rect key="frame" x="16" y="196" width="343" height="533"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="missionCell" id="ClA-kA-nKz" customClass="HistoryCell" customModule="TalTal" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="44.666666030883789" width="343" height="87.666664123535156"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ClA-kA-nKz" id="Nr6-vS-hi8">
-                                            <rect key="frame" x="0.0" y="0.0" width="343" height="87.666664123535156"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="RRW-LA-fNK">
-                                                    <rect key="frame" x="0.0" y="6" width="343" height="75.666666666666671"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Jao-N8-my8">
+                                <rect key="frame" x="16" y="98.666666666666686" width="343" height="630.33333333333326"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="기록" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2DG-cM-HgV">
+                                        <rect key="frame" x="0.0" y="0.0" width="343" height="40.666666666666664"/>
+                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="34"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="ege-A2-Oop">
+                                        <rect key="frame" x="0.0" y="60.666666666666671" width="343" height="32"/>
+                                        <segments>
+                                            <segment title="일간 미션"/>
+                                            <segment title="주간 미션"/>
+                                        </segments>
+                                        <color key="selectedSegmentTintColor" name="PointPink"/>
+                                        <connections>
+                                            <action selector="switchMissionType:" destination="Y6W-OH-hqX" eventType="valueChanged" id="0zl-W0-TaS"/>
+                                        </connections>
+                                    </segmentedControl>
+                                    <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="TMn-Q6-S1c">
+                                        <rect key="frame" x="0.0" y="111.66666666666669" width="343" height="518.66666666666652"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <prototypes>
+                                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="missionCell" id="ClA-kA-nKz" customClass="HistoryCell" customModule="TalTal" customModuleProvider="target">
+                                                <rect key="frame" x="0.0" y="44.666666030883789" width="343" height="87.666664123535156"/>
+                                                <autoresizingMask key="autoresizingMask"/>
+                                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ClA-kA-nKz" id="Nr6-vS-hi8">
+                                                    <rect key="frame" x="0.0" y="0.0" width="343" height="87.666664123535156"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
                                                     <subviews>
-                                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XiI-Kg-rvv">
-                                                            <rect key="frame" x="20" y="19.999999999999996" width="303" height="35.666666666666657"/>
+                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="RRW-LA-fNK">
+                                                            <rect key="frame" x="0.0" y="6" width="343" height="75.666666666666671"/>
                                                             <subviews>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="미션이 들어갈 자리" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EMQ-6S-8sq">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="303" height="17"/>
-                                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                                    <nil key="textColor"/>
-                                                                    <nil key="highlightedColor"/>
-                                                                </label>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="날짜가 들어갈 자리" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vif-gp-oxx">
-                                                                    <rect key="frame" x="0.0" y="21" width="303" height="14.666666666666664"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="height" constant="14.666666666666664" id="jyy-Vi-WU0"/>
-                                                                    </constraints>
-                                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                                    <color key="textColor" name="TextDarkGray"/>
-                                                                    <nil key="highlightedColor"/>
-                                                                </label>
+                                                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XiI-Kg-rvv">
+                                                                    <rect key="frame" x="20" y="19.999999999999996" width="303" height="35.666666666666657"/>
+                                                                    <subviews>
+                                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="미션이 들어갈 자리" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EMQ-6S-8sq">
+                                                                            <rect key="frame" x="0.0" y="0.0" width="303" height="17"/>
+                                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                                            <nil key="textColor"/>
+                                                                            <nil key="highlightedColor"/>
+                                                                        </label>
+                                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="날짜가 들어갈 자리" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vif-gp-oxx">
+                                                                            <rect key="frame" x="0.0" y="21" width="303" height="14.666666666666664"/>
+                                                                            <constraints>
+                                                                                <constraint firstAttribute="height" constant="14.666666666666664" id="jyy-Vi-WU0"/>
+                                                                            </constraints>
+                                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                                            <color key="textColor" name="TextDarkGray"/>
+                                                                            <nil key="highlightedColor"/>
+                                                                        </label>
+                                                                    </subviews>
+                                                                </stackView>
                                                             </subviews>
-                                                        </stackView>
+                                                            <constraints>
+                                                                <constraint firstItem="XiI-Kg-rvv" firstAttribute="leading" secondItem="RRW-LA-fNK" secondAttribute="leading" constant="20" id="WZ3-gw-32Y"/>
+                                                                <constraint firstAttribute="trailing" secondItem="XiI-Kg-rvv" secondAttribute="trailing" constant="20" id="aTd-9A-7zO"/>
+                                                                <constraint firstItem="XiI-Kg-rvv" firstAttribute="top" secondItem="RRW-LA-fNK" secondAttribute="top" constant="20" id="if8-Am-m8R"/>
+                                                                <constraint firstAttribute="bottom" secondItem="XiI-Kg-rvv" secondAttribute="bottom" constant="20" id="oPo-fx-fpH"/>
+                                                            </constraints>
+                                                        </view>
                                                     </subviews>
                                                     <constraints>
-                                                        <constraint firstItem="XiI-Kg-rvv" firstAttribute="leading" secondItem="RRW-LA-fNK" secondAttribute="leading" constant="20" id="WZ3-gw-32Y"/>
-                                                        <constraint firstAttribute="trailing" secondItem="XiI-Kg-rvv" secondAttribute="trailing" constant="20" id="aTd-9A-7zO"/>
-                                                        <constraint firstItem="XiI-Kg-rvv" firstAttribute="top" secondItem="RRW-LA-fNK" secondAttribute="top" constant="20" id="if8-Am-m8R"/>
-                                                        <constraint firstAttribute="bottom" secondItem="XiI-Kg-rvv" secondAttribute="bottom" constant="20" id="oPo-fx-fpH"/>
+                                                        <constraint firstItem="RRW-LA-fNK" firstAttribute="leading" secondItem="Nr6-vS-hi8" secondAttribute="leading" id="MMB-g2-QOk"/>
+                                                        <constraint firstAttribute="bottom" secondItem="RRW-LA-fNK" secondAttribute="bottom" constant="6" id="Z9X-5X-cXO"/>
+                                                        <constraint firstAttribute="trailing" secondItem="RRW-LA-fNK" secondAttribute="trailing" id="gAO-lB-ueY"/>
+                                                        <constraint firstItem="RRW-LA-fNK" firstAttribute="top" secondItem="Nr6-vS-hi8" secondAttribute="top" constant="6" id="wOH-oS-bt9"/>
                                                     </constraints>
-                                                </view>
-                                            </subviews>
-                                            <constraints>
-                                                <constraint firstItem="RRW-LA-fNK" firstAttribute="leading" secondItem="Nr6-vS-hi8" secondAttribute="leading" id="MMB-g2-QOk"/>
-                                                <constraint firstAttribute="bottom" secondItem="RRW-LA-fNK" secondAttribute="bottom" constant="6" id="Z9X-5X-cXO"/>
-                                                <constraint firstAttribute="trailing" secondItem="RRW-LA-fNK" secondAttribute="trailing" id="gAO-lB-ueY"/>
-                                                <constraint firstItem="RRW-LA-fNK" firstAttribute="top" secondItem="Nr6-vS-hi8" secondAttribute="top" constant="6" id="wOH-oS-bt9"/>
-                                            </constraints>
-                                        </tableViewCellContentView>
-                                        <connections>
-                                            <outlet property="cellView" destination="RRW-LA-fNK" id="dud-Uy-hve"/>
-                                            <outlet property="dateLabel" destination="Vif-gp-oxx" id="hJx-dF-uYp"/>
-                                            <outlet property="missionLabel" destination="EMQ-6S-8sq" id="AwS-ly-ak9"/>
-                                        </connections>
-                                    </tableViewCell>
-                                </prototypes>
-                            </tableView>
+                                                </tableViewCellContentView>
+                                                <connections>
+                                                    <outlet property="cellView" destination="RRW-LA-fNK" id="dud-Uy-hve"/>
+                                                    <outlet property="dateLabel" destination="Vif-gp-oxx" id="hJx-dF-uYp"/>
+                                                    <outlet property="missionLabel" destination="EMQ-6S-8sq" id="AwS-ly-ak9"/>
+                                                </connections>
+                                            </tableViewCell>
+                                        </prototypes>
+                                    </tableView>
+                                </subviews>
+                            </stackView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="TMn-Q6-S1c" secondAttribute="trailing" constant="16" id="8gP-gT-0i8"/>
-                            <constraint firstItem="TMn-Q6-S1c" firstAttribute="top" secondItem="ege-A2-Oop" secondAttribute="bottom" constant="20" id="9vA-74-zSF"/>
-                            <constraint firstItem="TMn-Q6-S1c" firstAttribute="bottom" secondItem="vDu-zF-Fre" secondAttribute="bottom" id="BJ0-kI-UNL"/>
-                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="ege-A2-Oop" secondAttribute="trailing" constant="16" id="F7Z-6K-YSe"/>
-                            <constraint firstItem="ege-A2-Oop" firstAttribute="top" secondItem="2DG-cM-HgV" secondAttribute="bottom" constant="20" id="MGF-To-lnP"/>
-                            <constraint firstItem="TMn-Q6-S1c" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="16" id="kc0-WN-jLE"/>
-                            <constraint firstItem="ege-A2-Oop" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="16" id="o8R-Pf-7KK"/>
-                            <constraint firstItem="2DG-cM-HgV" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="44" id="ojr-yp-d6h"/>
-                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="2DG-cM-HgV" secondAttribute="trailing" constant="16" id="piy-dH-X3L"/>
-                            <constraint firstItem="TMn-Q6-S1c" firstAttribute="trailing" secondItem="ege-A2-Oop" secondAttribute="trailing" id="ruw-jY-kFD"/>
-                            <constraint firstItem="TMn-Q6-S1c" firstAttribute="leading" secondItem="ege-A2-Oop" secondAttribute="leading" id="yaS-co-6K7"/>
-                            <constraint firstItem="2DG-cM-HgV" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="16" id="zz9-Hl-o14"/>
+                            <constraint firstItem="dXH-Tq-Ujw" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="16" id="3sb-ad-7Ey" userLabel="404TopLable Leading"/>
+                            <constraint firstItem="Jao-N8-my8" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="E3V-KP-oSq"/>
+                            <constraint firstItem="dXH-Tq-Ujw" firstAttribute="height" secondItem="vDu-zF-Fre" secondAttribute="height" multiplier="0.08" id="J2f-hY-Y3x" userLabel="404TopLable Height "/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="bottom" secondItem="Jao-N8-my8" secondAttribute="bottom" id="aVp-U0-uZT" userLabel="Stack View Bottom"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="dXH-Tq-Ujw" secondAttribute="trailing" constant="16" id="anI-2F-cUk" userLabel="404TopLabel Trailing"/>
+                            <constraint firstItem="dXH-Tq-Ujw" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" id="gKR-54-cg8" userLabel="404TopLable Top"/>
+                            <constraint firstItem="Jao-N8-my8" firstAttribute="width" secondItem="dXH-Tq-Ujw" secondAttribute="width" id="ktA-JG-jnh" userLabel="Stack View Width"/>
+                            <constraint firstItem="Jao-N8-my8" firstAttribute="top" secondItem="dXH-Tq-Ujw" secondAttribute="bottom" id="yUh-X3-7He" userLabel="Stack View Top"/>
                         </constraints>
                     </view>
                     <tabBarItem key="tabBarItem" title="History" image="square.text.square" catalog="system" id="uUb-wh-bae"/>

--- a/TalTal/TalTal/StoryBoard/History.storyboard
+++ b/TalTal/TalTal/StoryBoard/History.storyboard
@@ -110,7 +110,7 @@
                             <constraint firstItem="2DG-cM-HgV" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="16" id="zz9-Hl-o14"/>
                         </constraints>
                     </view>
-                    <tabBarItem key="tabBarItem" title="History" image="square.and.arrow.up.on.square.fill" catalog="system" id="uUb-wh-bae"/>
+                    <tabBarItem key="tabBarItem" title="History" image="square.text.square" catalog="system" id="uUb-wh-bae"/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
                         <outlet property="historyMainLabel" destination="2DG-cM-HgV" id="7mE-Z1-QKF"/>
@@ -125,9 +125,9 @@
         </scene>
     </scenes>
     <resources>
-        <image name="square.and.arrow.up.on.square.fill" catalog="system" width="117" height="128"/>
+        <image name="square.text.square" catalog="system" width="128" height="114"/>
         <namedColor name="PointPink">
-            <color red="1" green="0.50588235294117645" blue="0.40000000000000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="1" green="0.50599998235702515" blue="0.40000000596046448" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="TextDarkGray">
             <color red="0.54117647058823526" green="0.54117647058823526" blue="0.55686274509803924" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>


### PR DESCRIPTION
## 개요
히스토리뷰의 오토레이아웃을 수정했습니다.

## 작업사항
<img src="https://user-images.githubusercontent.com/103024840/181446620-a0390c69-65b8-458f-affe-d0c48bf62afe.png" width="300">
<img src="https://user-images.githubusercontent.com/103024840/181451762-0ef2dd2e-ff21-470a-9bb7-27c13170d072.png" width="300">
두 뷰의 높이가 같도록 수정완료

## 변경 혹은 추가 사항 설명
자세한 내용은 질문 해주시면 답변 해드리겠습니다.

