### PR TITLE
[2022.07.29] MissionClear Storyboard 오토레이아웃 수정

### DIFF
--- a/TalTal/TalTal/ AppDelegate.swift
+++ b/TalTal/TalTal/ AppDelegate.swift
@@ -8,6 +8,7 @@
 import UIKit
 import CoreData
 
+
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 

--- a/TalTal/TalTal/StoryBoard/MissionClear.storyboard
+++ b/TalTal/TalTal/StoryBoard/MissionClear.storyboard
@@ -17,104 +17,84 @@
                         <rect key="frame" x="0.0" y="0.0" width="428" height="872"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="미션 완료" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dWg-Ml-Sg7">
-                                <rect key="frame" x="182.66666666666666" y="14" width="63" height="21"/>
-                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="일일 미션" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ASJ-Ji-XEc">
-                                <rect key="frame" x="20" y="78" width="70" height="25"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="일일 미션" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ASJ-Ji-XEc">
+                                <rect key="frame" x="20" y="285" width="70" height="25"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" name="PointPink"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="70" id="2gj-T4-ii2"/>
-                                    <constraint firstAttribute="height" constant="25" id="eiU-eC-N8h"/>
-                                </constraints>
                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="14"/>
                                 <color key="textColor" name="White"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="퀘스트 Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xii-Cp-8Ij">
-                                <rect key="frame" x="20" y="125" width="117" height="29"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="퀘스트 Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xii-Cp-8Ij">
+                                <rect key="frame" x="20" y="332" width="117" height="29"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="24"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="미션을 진행해 보니 어떤 느낌이 들었나요?" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4Ro-dN-Ltm">
-                                <rect key="frame" x="20" y="161" width="264" height="20"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="미션을 진행해 보니 어떤 느낌이 들었나요?" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4Ro-dN-Ltm">
+                                <rect key="frame" x="20" y="368" width="264" height="20"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="16"/>
                                 <color key="textColor" red="0.59999999999999998" green="0.59999999999999998" blue="0.59999999999999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uiD-AI-hID">
-                                <rect key="frame" x="20" y="196" width="388" height="136"/>
+                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uiD-AI-hID">
+                                <rect key="frame" x="20" y="403" width="388" height="136"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <subviews>
-                                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="50자 이내로 적어주세요." translatesAutoresizingMaskIntoConstraints="NO" id="QWg-fT-OIy">
+                                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" text="50자 이내로 적어주세요." translatesAutoresizingMaskIntoConstraints="NO" id="QWg-fT-OIy">
                                         <rect key="frame" x="16" y="8" width="356" height="120"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <color key="textColor" red="0.7803921568627451" green="0.7803921568627451" blue="0.80000000000000004" alpha="1" colorSpace="calibratedRGB"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                     </textView>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0 / 50" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ARp-hV-lF9">
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="0 / 50" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ARp-hV-lF9">
                                         <rect key="frame" x="340" y="109" width="38" height="17"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <color key="textColor" red="0.7803921568627451" green="0.7803921568627451" blue="0.80000000000000004" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
                                 <color key="backgroundColor" systemColor="systemGray2Color"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="136" id="242-CP-wLU"/>
-                                    <constraint firstAttribute="trailing" secondItem="ARp-hV-lF9" secondAttribute="trailing" constant="10" id="7Ea-RT-AWU"/>
-                                    <constraint firstAttribute="bottom" secondItem="QWg-fT-OIy" secondAttribute="bottom" constant="8" id="Xyg-mB-jjw"/>
-                                    <constraint firstItem="QWg-fT-OIy" firstAttribute="leading" secondItem="uiD-AI-hID" secondAttribute="leading" constant="16" id="a6q-5Q-9kg"/>
-                                    <constraint firstAttribute="trailing" secondItem="QWg-fT-OIy" secondAttribute="trailing" constant="16" id="lpo-Gv-kfj"/>
-                                    <constraint firstAttribute="bottom" secondItem="ARp-hV-lF9" secondAttribute="bottom" constant="10" id="mgv-Ty-72C"/>
-                                    <constraint firstItem="QWg-fT-OIy" firstAttribute="top" secondItem="uiD-AI-hID" secondAttribute="top" constant="8" id="v4d-fT-oC3"/>
-                                </constraints>
                             </view>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" role="cancel" translatesAutoresizingMaskIntoConstraints="NO" id="4nK-dj-yst">
-                                <rect key="frame" x="8" y="14" width="54" height="31"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="취소"/>
-                                <connections>
-                                    <action selector="actionBtnCancel:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="9TE-J6-2R9"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WbU-mE-6UW">
-                                <rect key="frame" x="371" y="14" width="49" height="31"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="확인"/>
-                                <connections>
-                                    <action selector="actionBtnConfirm:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="yNW-ro-a2d"/>
-                                </connections>
-                            </button>
+                            <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="G9b-7u-RMk">
+                                <rect key="frame" x="0.0" y="0.0" width="428" height="56"/>
+                                <items>
+                                    <navigationItem title="미션완료" id="5QE-MJ-Hun">
+                                        <barButtonItem key="leftBarButtonItem" style="plain" id="8i6-X7-iqO">
+                                            <button key="customView" opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" id="lUl-IQ-osJ">
+                                                <rect key="frame" x="20" y="11" width="95" height="34.333333333333336"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <state key="normal" title="Button"/>
+                                                <buttonConfiguration key="configuration" style="plain" title="취소"/>
+                                            </button>
+                                        </barButtonItem>
+                                        <barButtonItem key="rightBarButtonItem" style="plain" id="Rcj-aH-BZk">
+                                            <button key="customView" opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" id="4Dz-i0-Lzh">
+                                                <rect key="frame" x="313" y="11" width="95" height="34.333333333333336"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <state key="normal" title="Button"/>
+                                                <buttonConfiguration key="configuration" style="plain" title="확인"/>
+                                            </button>
+                                        </barButtonItem>
+                                    </navigationItem>
+                                </items>
+                            </navigationBar>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="ASJ-Ji-XEc" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="78" id="2Dp-h4-kkp"/>
-                            <constraint firstItem="ASJ-Ji-XEc" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="20" id="DGX-tV-t2h"/>
-                            <constraint firstItem="xii-Cp-8Ij" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="20" id="FKl-CS-Is4"/>
-                            <constraint firstItem="uiD-AI-hID" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="20" id="MHa-4S-nzm"/>
-                            <constraint firstItem="uiD-AI-hID" firstAttribute="top" secondItem="4Ro-dN-Ltm" secondAttribute="bottom" constant="15" id="Nnx-Ce-CFR"/>
-                            <constraint firstItem="dWg-Ml-Sg7" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="14" id="UAw-vk-QyZ"/>
-                            <constraint firstItem="dWg-Ml-Sg7" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="dSc-N6-OTS"/>
-                            <constraint firstItem="4Ro-dN-Ltm" firstAttribute="top" secondItem="xii-Cp-8Ij" secondAttribute="bottom" constant="7" id="gYH-0q-wY7"/>
-                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="WbU-mE-6UW" secondAttribute="trailing" constant="8" id="lT0-cB-EFU"/>
-                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="uiD-AI-hID" secondAttribute="trailing" constant="20" id="oFE-2Y-Plg"/>
-                            <constraint firstItem="4Ro-dN-Ltm" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="20" id="p46-jf-QsR"/>
-                            <constraint firstItem="WbU-mE-6UW" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="14" id="qx4-GA-Wrs"/>
-                            <constraint firstItem="xii-Cp-8Ij" firstAttribute="top" secondItem="ASJ-Ji-XEc" secondAttribute="bottom" constant="22" id="su0-85-ZBI"/>
+                            <constraint firstItem="G9b-7u-RMk" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" id="JnT-gm-9wK"/>
+                            <constraint firstItem="G9b-7u-RMk" firstAttribute="width" secondItem="5EZ-qb-Rvc" secondAttribute="width" id="LEH-5O-XC7"/>
+                            <constraint firstItem="G9b-7u-RMk" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="a3Y-Rh-mdp"/>
                         </constraints>
                     </view>
-                    <navigationItem key="navigationItem" id="FVY-kQ-lYS"/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
-                        <outlet property="cancelButton" destination="4nK-dj-yst" id="EKS-dS-7Rq"/>
-                        <outlet property="confirmButton" destination="WbU-mE-6UW" id="V0s-xh-lFG"/>
                         <outlet property="missionTypeLabel" destination="ASJ-Ji-XEc" id="jSh-ya-EQb"/>
                         <outlet property="reflectionTextCountLable" destination="ARp-hV-lF9" id="0rN-n7-u0O"/>
                         <outlet property="reflectionTextView" destination="QWg-fT-OIy" id="riq-PW-fXS"/>
@@ -163,7 +143,7 @@
     <resources>
         <image name="pencil.circle.fill" catalog="system" width="128" height="121"/>
         <namedColor name="PointPink">
-            <color red="1" green="0.50588235294117645" blue="0.40000000000000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="1" green="0.50599998235702515" blue="0.40000000596046448" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="White">
             <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/TalTal/TalTal/StoryBoard/MissionClear.storyboard
+++ b/TalTal/TalTal/StoryBoard/MissionClear.storyboard
@@ -31,33 +31,10 @@
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cxs-gx-qlp" userLabel="404TopLabel">
                                 <rect key="frame" x="0.0" y="56" width="428" height="26"/>
-                                <color key="backgroundColor" name="AccentColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uiD-AI-hID">
-                                <rect key="frame" x="16" y="202" width="388" height="136"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <subviews>
-                                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" text="50자 이내로 적어주세요." translatesAutoresizingMaskIntoConstraints="NO" id="QWg-fT-OIy">
-                                        <rect key="frame" x="16" y="8" width="356" height="120"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                        <color key="textColor" red="0.7803921568627451" green="0.7803921568627451" blue="0.80000000000000004" alpha="1" colorSpace="calibratedRGB"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                        <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
-                                    </textView>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="0 / 50" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ARp-hV-lF9">
-                                        <rect key="frame" x="340" y="109" width="38" height="17"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                        <color key="textColor" red="0.7803921568627451" green="0.7803921568627451" blue="0.80000000000000004" alpha="1" colorSpace="calibratedRGB"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                </subviews>
-                                <color key="backgroundColor" systemColor="systemGray2Color"/>
-                            </view>
                             <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="G9b-7u-RMk">
                                 <rect key="frame" x="0.0" y="0.0" width="428" height="56"/>
                                 <items>
@@ -80,17 +57,53 @@
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XXn-TR-p0r" userLabel="404Top2edLabel">
                                 <rect key="frame" x="0.0" y="110" width="428" height="26.333333333333343"/>
-                                <color key="backgroundColor" name="AccentColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KHL-1S-Krg" userLabel="404Top3rdLabel">
+                                <rect key="frame" x="0.0" y="189.33333333333334" width="428" height="21.666666666666657"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uiD-AI-hID">
+                                <rect key="frame" x="16" y="211" width="396" height="139.66666666666663"/>
+                                <subviews>
+                                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="50자 이내로 적어주세요." translatesAutoresizingMaskIntoConstraints="NO" id="QWg-fT-OIy">
+                                        <rect key="frame" x="10" y="5" width="376" height="129.66666666666666"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <color key="textColor" red="0.7803921568627451" green="0.7803921568627451" blue="0.80000000000000004" alpha="1" colorSpace="calibratedRGB"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                    </textView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0 / 50" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ARp-hV-lF9">
+                                        <rect key="frame" x="10" y="117.66666666666669" width="376" height="17"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <color key="textColor" red="0.7803921568627451" green="0.7803921568627451" blue="0.80000000000000004" alpha="1" colorSpace="calibratedRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" systemColor="systemGray2Color"/>
+                                <constraints>
+                                    <constraint firstItem="ARp-hV-lF9" firstAttribute="width" secondItem="QWg-fT-OIy" secondAttribute="width" id="1OX-Ev-H2F"/>
+                                    <constraint firstItem="QWg-fT-OIy" firstAttribute="centerY" secondItem="uiD-AI-hID" secondAttribute="centerY" id="B2c-nK-C1k"/>
+                                    <constraint firstItem="QWg-fT-OIy" firstAttribute="height" secondItem="uiD-AI-hID" secondAttribute="height" constant="-10" id="Wco-3c-8cA"/>
+                                    <constraint firstItem="ARp-hV-lF9" firstAttribute="trailing" secondItem="QWg-fT-OIy" secondAttribute="trailing" id="Wg7-qm-j40"/>
+                                    <constraint firstItem="QWg-fT-OIy" firstAttribute="width" secondItem="uiD-AI-hID" secondAttribute="width" constant="-20" id="m32-Rj-gUp"/>
+                                    <constraint firstItem="QWg-fT-OIy" firstAttribute="centerX" secondItem="uiD-AI-hID" secondAttribute="centerX" id="nN1-Ig-eHX"/>
+                                    <constraint firstItem="ARp-hV-lF9" firstAttribute="bottom" secondItem="QWg-fT-OIy" secondAttribute="bottom" id="pis-eo-oIo"/>
+                                </constraints>
+                            </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="XXn-TR-p0r" firstAttribute="width" secondItem="5EZ-qb-Rvc" secondAttribute="width" id="8gd-F2-HZz"/>
+                            <constraint firstItem="KHL-1S-Krg" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="AEi-ee-JNS"/>
+                            <constraint firstItem="KHL-1S-Krg" firstAttribute="top" secondItem="4Ro-dN-Ltm" secondAttribute="bottom" id="Edv-2D-OIg"/>
                             <constraint firstItem="xii-Cp-8Ij" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="16" id="H7K-DF-eEi"/>
+                            <constraint firstItem="uiD-AI-hID" firstAttribute="top" secondItem="KHL-1S-Krg" secondAttribute="bottom" id="HJC-yp-Vxg"/>
                             <constraint firstItem="G9b-7u-RMk" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" id="JnT-gm-9wK"/>
                             <constraint firstItem="G9b-7u-RMk" firstAttribute="width" secondItem="5EZ-qb-Rvc" secondAttribute="width" id="LEH-5O-XC7"/>
                             <constraint firstItem="ASJ-Ji-XEc" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="16" id="N3L-Ig-58N"/>
@@ -102,10 +115,15 @@
                             <constraint firstItem="XXn-TR-p0r" firstAttribute="top" secondItem="ASJ-Ji-XEc" secondAttribute="bottom" id="VzG-Ve-uMV"/>
                             <constraint firstItem="Cxs-gx-qlp" firstAttribute="top" secondItem="G9b-7u-RMk" secondAttribute="bottom" id="XFn-C4-UIx"/>
                             <constraint firstItem="G9b-7u-RMk" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="a3Y-Rh-mdp"/>
+                            <constraint firstItem="uiD-AI-hID" firstAttribute="height" secondItem="5EZ-qb-Rvc" secondAttribute="height" multiplier="0.16" id="ex5-6m-ZdM"/>
                             <constraint firstItem="Cxs-gx-qlp" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="lRl-0n-Uw2"/>
                             <constraint firstItem="XXn-TR-p0r" firstAttribute="height" secondItem="5EZ-qb-Rvc" secondAttribute="height" multiplier="0.03" id="oyj-0d-Tqk"/>
                             <constraint firstItem="4Ro-dN-Ltm" firstAttribute="top" secondItem="xii-Cp-8Ij" secondAttribute="bottom" constant="4" id="qHg-Gi-jl3" userLabel="미션을 ...Top"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="uiD-AI-hID" secondAttribute="trailing" constant="16" id="rIK-oP-8wZ"/>
                             <constraint firstItem="XXn-TR-p0r" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="rxh-jc-lsG"/>
+                            <constraint firstItem="uiD-AI-hID" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="16" id="unl-1A-AcX"/>
+                            <constraint firstItem="KHL-1S-Krg" firstAttribute="height" secondItem="5EZ-qb-Rvc" secondAttribute="height" multiplier="0.025" id="vRi-hn-SPV"/>
+                            <constraint firstItem="KHL-1S-Krg" firstAttribute="width" secondItem="5EZ-qb-Rvc" secondAttribute="width" id="yUL-yL-f13"/>
                         </constraints>
                     </view>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
@@ -157,9 +175,6 @@
     </scenes>
     <resources>
         <image name="pencil.circle.fill" catalog="system" width="128" height="121"/>
-        <namedColor name="AccentColor">
-            <color red="0.0" green="0.46000000000000002" blue="0.89000000000000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
         <namedColor name="PointPink">
             <color red="1" green="0.50599998235702515" blue="0.40000000596046448" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>

--- a/TalTal/TalTal/StoryBoard/MissionClear.storyboard
+++ b/TalTal/TalTal/StoryBoard/MissionClear.storyboard
@@ -17,30 +17,27 @@
                         <rect key="frame" x="0.0" y="0.0" width="428" height="872"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="일일 미션" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ASJ-Ji-XEc">
-                                <rect key="frame" x="20" y="285" width="70" height="25"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" name="PointPink"/>
-                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="14"/>
-                                <color key="textColor" name="White"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="퀘스트 Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xii-Cp-8Ij">
-                                <rect key="frame" x="20" y="332" width="117" height="29"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="퀘스트 Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xii-Cp-8Ij">
+                                <rect key="frame" x="16" y="136.33333333333334" width="117" height="29"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="24"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="미션을 진행해 보니 어떤 느낌이 들었나요?" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4Ro-dN-Ltm">
-                                <rect key="frame" x="20" y="368" width="264" height="20"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="미션을 진행해 보니 어떤 느낌이 들었나요?" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4Ro-dN-Ltm">
+                                <rect key="frame" x="16" y="169.33333333333334" width="264" height="20"/>
                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="16"/>
                                 <color key="textColor" red="0.59999999999999998" green="0.59999999999999998" blue="0.59999999999999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cxs-gx-qlp" userLabel="404TopLabel">
+                                <rect key="frame" x="0.0" y="56" width="428" height="26"/>
+                                <color key="backgroundColor" name="AccentColor"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                             <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uiD-AI-hID">
-                                <rect key="frame" x="20" y="403" width="388" height="136"/>
+                                <rect key="frame" x="16" y="202" width="388" height="136"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <subviews>
                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" text="50자 이내로 적어주세요." translatesAutoresizingMaskIntoConstraints="NO" id="QWg-fT-OIy">
@@ -64,33 +61,51 @@
                             <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="G9b-7u-RMk">
                                 <rect key="frame" x="0.0" y="0.0" width="428" height="56"/>
                                 <items>
-                                    <navigationItem title="미션완료" id="5QE-MJ-Hun">
-                                        <barButtonItem key="leftBarButtonItem" style="plain" id="8i6-X7-iqO">
-                                            <button key="customView" opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" id="lUl-IQ-osJ">
-                                                <rect key="frame" x="20" y="11" width="95" height="34.333333333333336"/>
-                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                <state key="normal" title="Button"/>
-                                                <buttonConfiguration key="configuration" style="plain" title="취소"/>
-                                            </button>
-                                        </barButtonItem>
-                                        <barButtonItem key="rightBarButtonItem" style="plain" id="Rcj-aH-BZk">
-                                            <button key="customView" opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" id="4Dz-i0-Lzh">
-                                                <rect key="frame" x="313" y="11" width="95" height="34.333333333333336"/>
-                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                <state key="normal" title="Button"/>
-                                                <buttonConfiguration key="configuration" style="plain" title="확인"/>
-                                            </button>
-                                        </barButtonItem>
+                                    <navigationItem title="미션완료" id="rVD-IV-Yvn">
+                                        <barButtonItem key="leftBarButtonItem" title="취소" id="t9L-w7-cRO"/>
+                                        <barButtonItem key="rightBarButtonItem" title="확인" id="YBr-WC-ip1"/>
                                     </navigationItem>
                                 </items>
                             </navigationBar>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="일일 미션" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ASJ-Ji-XEc">
+                                <rect key="frame" x="16" y="82" width="75" height="28"/>
+                                <color key="backgroundColor" name="PointPink"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="28" id="3zl-T5-agQ"/>
+                                    <constraint firstAttribute="width" constant="75" id="wQF-iG-u8M"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="14"/>
+                                <color key="textColor" name="White"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XXn-TR-p0r" userLabel="404Top2edLabel">
+                                <rect key="frame" x="0.0" y="110" width="428" height="26.333333333333343"/>
+                                <color key="backgroundColor" name="AccentColor"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
+                            <constraint firstItem="XXn-TR-p0r" firstAttribute="width" secondItem="5EZ-qb-Rvc" secondAttribute="width" id="8gd-F2-HZz"/>
+                            <constraint firstItem="xii-Cp-8Ij" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="16" id="H7K-DF-eEi"/>
                             <constraint firstItem="G9b-7u-RMk" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" id="JnT-gm-9wK"/>
                             <constraint firstItem="G9b-7u-RMk" firstAttribute="width" secondItem="5EZ-qb-Rvc" secondAttribute="width" id="LEH-5O-XC7"/>
+                            <constraint firstItem="ASJ-Ji-XEc" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="16" id="N3L-Ig-58N"/>
+                            <constraint firstItem="Cxs-gx-qlp" firstAttribute="width" secondItem="5EZ-qb-Rvc" secondAttribute="width" id="OGX-by-H8f"/>
+                            <constraint firstItem="xii-Cp-8Ij" firstAttribute="top" secondItem="XXn-TR-p0r" secondAttribute="bottom" id="QH9-FA-fj4"/>
+                            <constraint firstItem="4Ro-dN-Ltm" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="16" id="Ryo-Ms-TBP" userLabel="미션을...leading"/>
+                            <constraint firstItem="ASJ-Ji-XEc" firstAttribute="top" secondItem="Cxs-gx-qlp" secondAttribute="bottom" id="Urb-2T-nry"/>
+                            <constraint firstItem="Cxs-gx-qlp" firstAttribute="height" secondItem="5EZ-qb-Rvc" secondAttribute="height" multiplier="0.03" id="Vfn-0J-eBS"/>
+                            <constraint firstItem="XXn-TR-p0r" firstAttribute="top" secondItem="ASJ-Ji-XEc" secondAttribute="bottom" id="VzG-Ve-uMV"/>
+                            <constraint firstItem="Cxs-gx-qlp" firstAttribute="top" secondItem="G9b-7u-RMk" secondAttribute="bottom" id="XFn-C4-UIx"/>
                             <constraint firstItem="G9b-7u-RMk" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="a3Y-Rh-mdp"/>
+                            <constraint firstItem="Cxs-gx-qlp" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="lRl-0n-Uw2"/>
+                            <constraint firstItem="XXn-TR-p0r" firstAttribute="height" secondItem="5EZ-qb-Rvc" secondAttribute="height" multiplier="0.03" id="oyj-0d-Tqk"/>
+                            <constraint firstItem="4Ro-dN-Ltm" firstAttribute="top" secondItem="xii-Cp-8Ij" secondAttribute="bottom" constant="4" id="qHg-Gi-jl3" userLabel="미션을 ...Top"/>
+                            <constraint firstItem="XXn-TR-p0r" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="rxh-jc-lsG"/>
                         </constraints>
                     </view>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
@@ -142,6 +157,9 @@
     </scenes>
     <resources>
         <image name="pencil.circle.fill" catalog="system" width="128" height="121"/>
+        <namedColor name="AccentColor">
+            <color red="0.0" green="0.46000000000000002" blue="0.89000000000000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
         <namedColor name="PointPink">
             <color red="1" green="0.50599998235702515" blue="0.40000000596046448" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>


### PR DESCRIPTION
## 개요
미션클리어뷰의 오토레이아웃을 수정했습니다.

## 작업사항
<img src="https://user-images.githubusercontent.com/103024840/181714800-98d760e3-ba1c-4b68-85a8-880a26168503.png" width="300">

## 변경 혹은 추가 사항 설명
Ruyha의 지도하에 Felix가 작업했습니다.
오래걸릴줄 알고 제 맥으로 해서 불가피하게 제거로 올라가는것 처럼 보입니다.

