### PR TITLE
[2022.07.31] 미션클리어 뷰에 미션 넘어가도록 연결 및 디자인 수정

### DIFF
--- a/TalTal/TalTal.xcodeproj/project.pbxproj
+++ b/TalTal/TalTal.xcodeproj/project.pbxproj
@@ -428,7 +428,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = P2UJWPTGRX;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TalTal/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -444,7 +444,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = developer.Toby.TalTal;
+				PRODUCT_BUNDLE_IDENTIFIER = developer.MC3.TalTal;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -459,7 +459,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = P2UJWPTGRX;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TalTal/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -475,7 +475,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = developer.Toby.TalTal;
+				PRODUCT_BUNDLE_IDENTIFIER = developer.MC3.TalTal;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/TalTal/TalTal/Controllers/Mission/MissionViewController.swift
+++ b/TalTal/TalTal/Controllers/Mission/MissionViewController.swift
@@ -24,17 +24,14 @@ final class MissionViewController: UIViewController {
      유저디폴트에서 주간 미션과 일간 미션을 받아오게 만들어서 아래의 변수에 넣거나
      함수에 값을가져오게 만들어주세요.
      */
-    var dailyBtnValue = true //true 클리어함
+    var dailyBtnValue = false //true 클리어함
     var weeklyBtnValue = false //false 아직클리어안함
     
-
-    //더미 데이터입니다.
     var dailyClearQuest = 5
-    var dailyQuestStirng = "햇빛이 선명하게 나뭇잎을 핥고 있었다.햇빛이 선명하게 나뭇잎을 핥고 있었다"
+    var dailyQuestStirng = "안녕하세요. 탈탈입니다."
     
-    //더미 데이터입니다.
     var weeklyClearQuest = 1
-    var weeklyQuestStirng = "햇빛이 선명하게 나뭇잎을 핥고 있었다.햇빛이 선명하게 나뭇잎을 핥고 있었다"
+    var weeklyQuestStirng = "안녕하세요. 탈탈입니다."
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -51,14 +48,22 @@ final class MissionViewController: UIViewController {
 //델리게이트 패턴을 사용해 데일리인지 위클리 인지 확인한다.
 extension MissionViewController : MissionQuestViewDelegate{
     func didQuestButton(type: MissionQuest) {
-        print("이거눌림 \(type)")
-        
         //코드로 뷰를 Show하는 부분 입니다.
         let storyboard = UIStoryboard(name: "MissionClear", bundle: nil)
         let secondVC = storyboard.instantiateViewController(identifier: "MissionClear") as! MissionClearViewController
         secondVC.missionType = type
         secondVC.delegate = self
+        secondVC.questLabelText = setQuestTextReturn(type: type)
         show(secondVC, sender: self)
+    }
+    
+    func setQuestTextReturn(type:MissionQuest) -> String{
+        switch type{
+        case.daily:
+            return dailyQuestStirng
+        case.weekly:
+            return weeklyQuestStirng
+        }
     }
 }
 

--- a/TalTal/TalTal/Controllers/MissionClearViewController.swift
+++ b/TalTal/TalTal/Controllers/MissionClearViewController.swift
@@ -15,9 +15,9 @@ protocol MissionClearViewDelegate {
 class MissionClearViewController: UIViewController {
     
     var delegate: MissionClearViewDelegate?
-    
     //타입설정
     var missionType : MissionQuest = .daily
+    var questLabelText = ""
     private var isTextViewSelected: Bool = true
 
 	@IBOutlet var missionTypeLabel: UILabel!
@@ -26,7 +26,10 @@ class MissionClearViewController: UIViewController {
 	@IBOutlet var reflectionTextCountLable: UILabel!
     @IBOutlet weak var cancelButton: UIBarButtonItem!
     @IBOutlet weak var confirmButton: UIBarButtonItem!
-
+    //퀘스트가 연결될 레이블
+    @IBOutlet weak var questLabel: UILabel!
+    
+    
     @IBAction func cancelButtonAction(_ sender: Any) {
         //TODO: Close Modal
         self.dismiss(animated: true, completion: nil)
@@ -48,6 +51,7 @@ class MissionClearViewController: UIViewController {
 		view.backgroundColor = UIColor(red: 248 / 255, green: 248 / 255, blue: 248 / 255, alpha: 1)
 		initMissionTypeLabel()
 		initReflection()
+        questLabel.text = questLabelText
 	}
 
 }
@@ -98,16 +102,18 @@ extension MissionClearViewController{
 extension MissionClearViewController: UITextViewDelegate {
 	func textViewDidChange(_ textView: UITextView) {
 		// 연속으로 Enter 입력시 방지
-		if textView.text.last == "\n" {
-			let index = textView.text.index(textView.text.endIndex, offsetBy: -2)
-			if textView.text[index] == "\n" {
-				let start = textView.text.startIndex
-				let end = textView.text.index(textView.text.endIndex, offsetBy: -1)
-				let range = start..<end
-				textView.text = String(textView.text[range])
-			}
-		}
-
+        // MARK: 버그있어서 주석처리하고 라인제한 걸었습니다.
+        // Toby확인해주세요 -Ruyha-
+//		if textView.text.last == "\n" {
+//			let index = textView.text.index(textView.text.endIndex, offsetBy: -2)
+//			if textView.text[index] == "\n" {
+//				let start = textView.text.startIndex
+//				let end = textView.text.index(textView.text.endIndex, offsetBy: -1)
+//				let range = start..<end
+//				textView.text = String(textView.text[range])
+//			}
+//		}
+//
 // 50 글자 이상 방지
 		if textView.text.count > 50 {
 			let start = textView.text.startIndex

--- a/TalTal/TalTal/StoryBoard/MissionClear.storyboard
+++ b/TalTal/TalTal/StoryBoard/MissionClear.storyboard
@@ -17,14 +17,14 @@
                         <rect key="frame" x="0.0" y="0.0" width="428" height="926"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="퀘스트 Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xii-Cp-8Ij">
-                                <rect key="frame" x="16" y="171.66666666666666" width="117" height="29"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="퀘스트 Title" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xii-Cp-8Ij">
+                                <rect key="frame" x="16" y="171.66666666666666" width="396" height="28.666666666666657"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="24"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="미션을 진행해 보니 어떤 느낌이 들었나요?" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4Ro-dN-Ltm">
-                                <rect key="frame" x="16" y="204.66666666666666" width="264" height="20"/>
+                                <rect key="frame" x="16" y="204.33333333333334" width="264" height="20"/>
                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="16"/>
                                 <color key="textColor" red="0.59999999999999998" green="0.59999999999999998" blue="0.59999999999999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
@@ -70,13 +70,13 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KHL-1S-Krg" userLabel="404Top3rdLabel">
-                                <rect key="frame" x="0.0" y="224.66666666666666" width="428" height="23"/>
+                                <rect key="frame" x="0.0" y="224.33333333333334" width="428" height="23"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uiD-AI-hID">
-                                <rect key="frame" x="16" y="247.66666666666663" width="396" height="148.33333333333337"/>
+                                <rect key="frame" x="16" y="247.33333333333331" width="396" height="148.33333333333331"/>
                                 <subviews>
                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="50자 이내로 적어주세요." translatesAutoresizingMaskIntoConstraints="NO" id="QWg-fT-OIy">
                                         <rect key="frame" x="10" y="5" width="376" height="138.33333333333334"/>
@@ -127,6 +127,7 @@
                             <constraint firstItem="Cxs-gx-qlp" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="lRl-0n-Uw2"/>
                             <constraint firstItem="XXn-TR-p0r" firstAttribute="height" secondItem="5EZ-qb-Rvc" secondAttribute="height" multiplier="0.03" id="oyj-0d-Tqk"/>
                             <constraint firstItem="4Ro-dN-Ltm" firstAttribute="top" secondItem="xii-Cp-8Ij" secondAttribute="bottom" constant="4" id="qHg-Gi-jl3" userLabel="미션을 ...Top"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="xii-Cp-8Ij" secondAttribute="trailing" constant="16" id="qbf-iI-bs4"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="uiD-AI-hID" secondAttribute="trailing" constant="16" id="rIK-oP-8wZ"/>
                             <constraint firstItem="XXn-TR-p0r" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="rxh-jc-lsG"/>
                             <constraint firstItem="uiD-AI-hID" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="16" id="unl-1A-AcX"/>
@@ -139,6 +140,7 @@
                         <outlet property="cancelButton" destination="t9L-w7-cRO" id="sQb-M3-csw"/>
                         <outlet property="confirmButton" destination="YBr-WC-ip1" id="zRj-P5-qJB"/>
                         <outlet property="missionTypeLabel" destination="ASJ-Ji-XEc" id="jSh-ya-EQb"/>
+                        <outlet property="questLabel" destination="xii-Cp-8Ij" id="N2w-Au-5OF"/>
                         <outlet property="reflectionTextCountLable" destination="ARp-hV-lF9" id="0rN-n7-u0O"/>
                         <outlet property="reflectionTextView" destination="QWg-fT-OIy" id="riq-PW-fXS"/>
                         <outlet property="reflectionView" destination="uiD-AI-hID" id="0YG-fH-vFG"/>


### PR DESCRIPTION
## 개요
미션클리어뷰 작업

## 작업사항
1. 미션 클리어뷰에 타이틀 레이블 코드와 연결 및 기획대로 2줄제한 추가
-(이런 기획적인 부분은 최초 view를 그릴때 작업이 되어 있어야 하는데 안되어있었습니다.. 눈물..)

2. 미션클리어뷰 타이틀에 해당 하는 미션이 들어가도록 수정했습니다.

## 변경 혹은 추가 사항 설명
제가 뷰 관련해서는 다른 분들이 하신 작업도 같이 수정하면서 하고 있지만...
당연하게 생각된 부분이 안되어 있는게 많아서 조금은 슬펐습니다....
방금 작업한 미션 클리어에도 당연히 미션의이보이는 레이블은 변동값이 들어가기 때문에
@IBOutlet 연결이 되어 었어야 하는데 이런 부분 부터 줄 라인 제한
그리고 딱 3분 만졌는데 발생한 버그들에 대한 주석도 안나와있어서 조금은 슬프네요...

