### PR TITLE
[2022.08.01] MissionViewController의 변수명 오타 수정 및 configureMission 에러 수정

### DIFF
--- a/TalTal/TalTal/Controllers/ReflectionViewController.swift
+++ b/TalTal/TalTal/Controllers/ReflectionViewController.swift
@@ -53,8 +53,13 @@ final class ReflectionViewController: UIViewController {
             break
         }
         
+        let now = Date.now
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "YYYY.MM.dd."
+        
         // 각 UILabel의 텍스트 설정
         missionLabel.text = missionData?.content
+        dateLabel.text = dateFormatter.string(from: missionData?.clearDate ?? Date.now)
         reflectionLabel.text = missionData?.reflection
         missionInformationLabel.text = missionData?.intention
         


### PR DESCRIPTION
## 개요
MissionViewController의 변수명 오타 수정 및 configureMission 에러 수정

## 작업사항
1. MissionViewController의 dailyMisson 변수 dailyMission으로 변수명 변경
2. 앱을 껐다 키면 코어데이터에 저장되는 내용이 달라지는 configureMission 메소드의 에러 수정

