### PR TITLE
[2022.08.02] 디테일 수정

### DIFF
--- a/TalTal/TalTal/ AppDelegate.swift
+++ b/TalTal/TalTal/ AppDelegate.swift
@@ -11,71 +11,78 @@ import CoreData
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
-	func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-		// Override point for customization after application launch.
-
-		return true
-	}
-
-	// MARK: UISceneSession Lifecycle
-
-	func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
-		// Called when a new scene session is being created.
-		// Use this method to select a configuration to create the new scene with.
-		return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
-	}
-
-	func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
-		// Called when the user discards a scene session.
-		// If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
-		// Use this method to release any resources that were specific to the discarded scenes, as they will not return.
-	}
-
-	// MARK: - Core Data stack
-
-	lazy var persistentContainer: NSPersistentContainer = {
-	    /*
-	     The persistent container for the application. This implementation
-	     creates and returns a container, having loaded the store for the
-	     application to it. This property is optional since there are legitimate
-	     error conditions that could cause the creation of the store to fail.
-	    */
-	    let container = NSPersistentContainer(name: "TalTal")
-	    container.loadPersistentStores(completionHandler: { (storeDescription, error) in
-	        if let error = error as NSError? {
-	            // Replace this implementation with code to handle the error appropriately.
-	            // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
-	             
-	            /*
-	             Typical reasons for an error here include:
-	             * The parent directory does not exist, cannot be created, or disallows writing.
-	             * The persistent store is not accessible, due to permissions or data protection when the device is locked.
-	             * The device is out of space.
-	             * The store could not be migrated to the current model version.
-	             Check the error message to determine what the actual problem was.
-	             */
-	            fatalError("Unresolved error \(error), \(error.userInfo)")
-	        }
-	    })
-	    return container
-	}()
-
-	// MARK: - Core Data Saving support
-
-	func saveContext () {
-	    let context = persistentContainer.viewContext
-	    if context.hasChanges {
-	        do {
-	            try context.save()
-	        } catch {
-	            // Replace this implementation with code to handle the error appropriately.
-	            // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
-	            let nserror = error as NSError
-	            fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
-	        }
-	    }
-	}
-
+    
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        
+        return true
+    }
+    
+    //세로 화면만 사용가능하도록 코드 추가
+    //TODO: xcode의 옵션값 만으로는 설정이 잘 안되어 부득이하게 코드로 추가
+    func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
+        return UIInterfaceOrientationMask.portrait
+    }
+    
+    
+    // MARK: UISceneSession Lifecycle
+    
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        // Called when a new scene session is being created.
+        // Use this method to select a configuration to create the new scene with.
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+    
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        // Called when the user discards a scene session.
+        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+    }
+    
+    // MARK: - Core Data stack
+    
+    lazy var persistentContainer: NSPersistentContainer = {
+        /*
+         The persistent container for the application. This implementation
+         creates and returns a container, having loaded the store for the
+         application to it. This property is optional since there are legitimate
+         error conditions that could cause the creation of the store to fail.
+         */
+        let container = NSPersistentContainer(name: "TalTal")
+        container.loadPersistentStores(completionHandler: { (storeDescription, error) in
+            if let error = error as NSError? {
+                // Replace this implementation with code to handle the error appropriately.
+                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
+                
+                /*
+                 Typical reasons for an error here include:
+                 * The parent directory does not exist, cannot be created, or disallows writing.
+                 * The persistent store is not accessible, due to permissions or data protection when the device is locked.
+                 * The device is out of space.
+                 * The store could not be migrated to the current model version.
+                 Check the error message to determine what the actual problem was.
+                 */
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+        })
+        return container
+    }()
+    
+    // MARK: - Core Data Saving support
+    
+    func saveContext () {
+        let context = persistentContainer.viewContext
+        if context.hasChanges {
+            do {
+                try context.save()
+            } catch {
+                // Replace this implementation with code to handle the error appropriately.
+                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
+                let nserror = error as NSError
+                fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
+            }
+        }
+    }
+    
 }
 

--- a/TalTal/TalTal/Controllers/Mission/MissionViewController.swift
+++ b/TalTal/TalTal/Controllers/Mission/MissionViewController.swift
@@ -4,13 +4,6 @@
 //
 //  Created by Ruyha on 2022/07/25.
 //
-//FIXME: 버튼 비활성화되었었을때 리로드 걸리면 색기본 색으로 나옴 RuyHa
-//MARK: 히스토리에 완료된 미션이 안보임
-//FIXME: 미션 클리어한 갯수 유저 디폴트에 키값 바꾸기 Joon
-//FIXME: 유저디폴트에 유저가 미션클리어 했는지를 확인해야됨. Joon
-//FIXME: 코어데이터와 로컬데이터 동기화
-//MARK: 히스토리뷰에 코어데이터 안넘어오는 이슈
-//완료시 FIXME로 수정
 
 import UIKit
 @IBDesignable

--- a/TalTal/TalTal/Controllers/Mission/MissionViewController.swift
+++ b/TalTal/TalTal/Controllers/Mission/MissionViewController.swift
@@ -86,7 +86,6 @@ extension MissionViewController: MissionClearViewDelegate {
         self.viewDidLoad()
         
         //TODO: 싱글톤 내에서 데이터 동기화 처리해야 함
-        
         questButtonIsUnabled(type: type)
     }
     
@@ -98,8 +97,11 @@ extension MissionViewController: MissionClearViewDelegate {
         switch type {
         case.daily:
             dailyView.questButtonClose()
+            dailyView.questButton.setTitle("오늘도 해냈어요!!", for: .normal)
         case.weekly:
             weeklyView.questButtonClose()
+            weeklyView.questButton.setTitle("이번주도 해냈어요!!", for: .normal)
+
         }
     }
     

--- a/TalTal/TalTal/Controllers/Mission/MissionViewController.swift
+++ b/TalTal/TalTal/Controllers/Mission/MissionViewController.swift
@@ -27,11 +27,12 @@ final class MissionViewController: UIViewController {
     var dailyBtnValue = UserDefaults.standard.bool(forKey: "isDailyMissionClear")
     var weeklyBtnValue = UserDefaults.standard.bool(forKey: "isWeeklyMissionClear")
     
-    var dailyClearQuest = 5
+    // 한눈에 봐도 에러가 보이는 화면으로 변경
+    var dailyClearQuest = 404
     var dailyQuestStirng = "안녕하세요. 탈탈입니다."
     
-    var weeklyClearQuest = 1
-    var weeklyQuestStirng = "안녕하세요. 탈탈입니다."
+    var weeklyClearQuest = 404
+    var weeklyQuestStirng = "앱을 재설치 해주세요."
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -199,13 +200,6 @@ extension MissionViewController {
         // TODO: 현재 작동에는 문제가 없지만 더 좋은 코드로 리팩토링 할 수 있을 것 같습니다. 추후에 변경하겠습니다.
         guard let currentDailyUserStage = MissionStage(rawValue: UserDefaults.standard.string(forKey: "dailyUserStage") ?? "") else { return }
         guard let currentWeeklyUserStage = MissionStage(rawValue: UserDefaults.standard.string(forKey: "weeklyUserStage") ?? "") else { return }
-        
-        // TODO: 모든 미션을 깬 경우 처리를 해야합니다(엔딩뷰)
-        // FIXME: 엔딩뷰 다른곳에서 처리해야됨 ㅇㅅㅇ
-//        if dailyMisson == nil && weeklyMission == nil {
-//            print("RIdkdkdkdkdkdr")
-//            return
-//        }
         
         // 앱에 접속한 날짜와 refresh가 되어야 할 날짜를 비교하기 위해 DateFormatter을 사용했습니다
         let now = Date.now

--- a/TalTal/TalTal/Models/MissionDataManager.swift
+++ b/TalTal/TalTal/Models/MissionDataManager.swift
@@ -152,6 +152,7 @@ class MissionDataManager {
 			if ele.stage == stage && ele.type == .weekly {
 				// filtermission에서 ele(이미 깬 값) 제거 / 제거할 값이 없어도 알아서 처리 됨
 				filterMissons.remove(.init(content: ele.content!, stage: stage, intention: ele.intention!))
+            }
 		}
 		
 		// 깨지 않은 Mission들 중에서 랜덤값 추출

--- a/TalTal/TalTal/StoryBoard/Reflection.storyboard
+++ b/TalTal/TalTal/StoryBoard/Reflection.storyboard
@@ -54,8 +54,8 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Rd6-vB-bFZ">
                                 <rect key="frame" x="16" y="197.5" width="382" height="136"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aAo-IN-zPB">
-                                        <rect key="frame" x="24" y="13" width="334" height="19.5"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="사용자가 추가한 회고" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aAo-IN-zPB">
+                                        <rect key="frame" x="24" y="13" width="334" height="110"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -65,6 +65,7 @@
                                 <constraints>
                                     <constraint firstItem="aAo-IN-zPB" firstAttribute="leading" secondItem="Rd6-vB-bFZ" secondAttribute="leading" constant="24" id="9LL-7V-aPr"/>
                                     <constraint firstAttribute="trailing" secondItem="aAo-IN-zPB" secondAttribute="trailing" constant="24" id="Iic-pA-z4v"/>
+                                    <constraint firstAttribute="bottom" secondItem="aAo-IN-zPB" secondAttribute="bottom" constant="13" id="R1C-jP-Eb2"/>
                                     <constraint firstAttribute="height" constant="136" id="R4b-WB-GI4"/>
                                     <constraint firstItem="aAo-IN-zPB" firstAttribute="top" secondItem="Rd6-vB-bFZ" secondAttribute="top" constant="13" id="sDg-vU-hsS"/>
                                 </constraints>
@@ -84,8 +85,8 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cnv-Xu-uBU">
                                 <rect key="frame" x="16" y="405" width="382" height="150"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZNC-ha-Em3">
-                                        <rect key="frame" x="24" y="13" width="334" height="19.5"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="미션의 의도" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZNC-ha-Em3">
+                                        <rect key="frame" x="24" y="13" width="334" height="124"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -96,6 +97,7 @@
                                     <constraint firstItem="ZNC-ha-Em3" firstAttribute="leading" secondItem="cnv-Xu-uBU" secondAttribute="leading" constant="24" id="0aT-1f-Q2z"/>
                                     <constraint firstAttribute="trailing" secondItem="ZNC-ha-Em3" secondAttribute="trailing" constant="24" id="HQh-BL-UBX"/>
                                     <constraint firstItem="ZNC-ha-Em3" firstAttribute="top" secondItem="cnv-Xu-uBU" secondAttribute="top" constant="13" id="ccI-yL-3v1"/>
+                                    <constraint firstAttribute="bottom" secondItem="ZNC-ha-Em3" secondAttribute="bottom" constant="13" id="mn0-qp-cYx"/>
                                     <constraint firstAttribute="height" constant="150" id="pVd-N8-QAw"/>
                                 </constraints>
                                 <userDefinedRuntimeAttributes>

--- a/TalTal/TalTal/Views/HistoryCell.swift
+++ b/TalTal/TalTal/Views/HistoryCell.swift
@@ -15,6 +15,10 @@ class HistoryCell: UITableViewCell {
 	
 	override func awakeFromNib() {
 		super.awakeFromNib()
+        // 테이블뷰 셀이 클릭 되었을때 백그라운드 컬러 제거
+        let backgroundView = UIView()
+        backgroundView.backgroundColor = UIColor.clear
+        selectedBackgroundView = backgroundView
 		// Initialization code
 	}
 	


### PR DESCRIPTION
## 개요
디테일을 수정했습니다.

## 작업사항
1. 히스토리 view에서 테이블뷰 셀 클릭시 배경이 회색에서 돌아오지 않아서 선택시 배경색이 변경되지 않도록 수정
2. Reflection View의 텍스트가 상하단 여백이 맞지 않아 label의 중앙에 오도록 오토레이아웃 수정
3. 세로 방향으로만 (정방향) 사용가능하도록 코드추가
4. 에러가 발생했을때 빠른 확인이 가능하도록 문구 수정
5. 미션 클리시 문구 변경 기존 미션완료 -> 오늘도 해냈어요!! 이번주도 해냈어요!! 로 수정

## 기타 이슈
1. 아이팟 터치 7세대 기준 미션이 2줄이 될시 뷰가 조금 안보이는 이슈가 있습니다.
- 미션클리어뷰,리플렉션뷰

2. 런치스크린을 추가해야합니다.
- 런치 스크린을 안 넣어도 심사에 통과한다는 말이 있긴하지만 있는게 좋아보입니다.

3. 이제 잘 수 있겠군요...
