### PR TITLE
[2022.08.03] 히스토리뷰 완료 미션이 없을 때, 알림문구 뷰잉 및 런치스크린 이미지 크기 수정

### DIFF
--- a/TalTal/TalTal/Base.lproj/LaunchScreen.storyboard
+++ b/TalTal/TalTal/Base.lproj/LaunchScreen.storyboard
@@ -16,24 +16,53 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="launchScreenimage" translatesAutoresizingMaskIntoConstraints="NO" id="8ay-du-JsI">
-                                <rect key="frame" x="0.0" y="241" width="414" height="414"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QAN-XF-DiR" userLabel="leading404label">
+                                <rect key="frame" x="0.0" y="44" width="103.5" height="818"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OQa-qm-2X1" userLabel="trailing404label">
+                                <rect key="frame" x="310.5" y="44" width="103.5" height="818"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BzE-o4-pQd" userLabel="center404label">
+                                <rect key="frame" x="103.5" y="44" width="207" height="818"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="launchScreenimage" translatesAutoresizingMaskIntoConstraints="NO" id="agp-99-shv">
+                                <rect key="frame" x="103.5" y="344.5" width="207" height="207"/>
                             </imageView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="8ay-du-JsI" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="4Yt-Mp-zQM"/>
-                            <constraint firstItem="8ay-du-JsI" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="NX2-Gi-1hJ"/>
-                            <constraint firstItem="8ay-du-JsI" firstAttribute="height" secondItem="Ze5-6b-2t3" secondAttribute="width" id="RMW-AD-fXN"/>
-                            <constraint firstItem="8ay-du-JsI" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="S58-uV-p1J"/>
-                            <constraint firstItem="8ay-du-JsI" firstAttribute="trailing" secondItem="6Tk-OE-BBY" secondAttribute="trailing" id="SUy-dg-Og0"/>
+                            <constraint firstItem="BzE-o4-pQd" firstAttribute="leading" secondItem="QAN-XF-DiR" secondAttribute="trailing" id="1Iy-Bv-Phd"/>
+                            <constraint firstItem="QAN-XF-DiR" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="2aQ-Js-6jH"/>
+                            <constraint firstItem="QAN-XF-DiR" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="4RH-Mm-D6e"/>
+                            <constraint firstItem="agp-99-shv" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="5oJ-Ub-dM9"/>
+                            <constraint firstItem="OQa-qm-2X1" firstAttribute="width" secondItem="Ze5-6b-2t3" secondAttribute="width" multiplier="0.25" id="9mb-KI-zRo"/>
+                            <constraint firstItem="agp-99-shv" firstAttribute="width" secondItem="BzE-o4-pQd" secondAttribute="width" id="QRK-Wi-vGi"/>
+                            <constraint firstItem="agp-99-shv" firstAttribute="height" secondItem="BzE-o4-pQd" secondAttribute="width" id="R73-rX-dek"/>
+                            <constraint firstItem="QAN-XF-DiR" firstAttribute="width" secondItem="Ze5-6b-2t3" secondAttribute="width" multiplier="0.25" id="R9m-nT-M9c"/>
+                            <constraint firstItem="QAN-XF-DiR" firstAttribute="bottom" secondItem="6Tk-OE-BBY" secondAttribute="bottom" id="S5a-6z-0Yo"/>
+                            <constraint firstItem="OQa-qm-2X1" firstAttribute="trailing" secondItem="6Tk-OE-BBY" secondAttribute="trailing" id="Wtt-l6-CkU"/>
+                            <constraint firstItem="BzE-o4-pQd" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="XjN-T3-MIp"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="BzE-o4-pQd" secondAttribute="bottom" id="ien-Pn-1CQ"/>
+                            <constraint firstItem="BzE-o4-pQd" firstAttribute="trailing" secondItem="OQa-qm-2X1" secondAttribute="leading" id="kNZ-LM-Sei"/>
+                            <constraint firstItem="agp-99-shv" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="vD9-fg-jGK"/>
+                            <constraint firstItem="OQa-qm-2X1" firstAttribute="bottom" secondItem="6Tk-OE-BBY" secondAttribute="bottom" id="wWC-Tf-vJm"/>
+                            <constraint firstItem="OQa-qm-2X1" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="wqk-kj-d8N"/>
                         </constraints>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="53" y="375"/>
+            <point key="canvasLocation" x="52.173913043478265" y="375"/>
         </scene>
     </scenes>
     <resources>

--- a/TalTal/TalTal/Controllers/HistoryViewController.swift
+++ b/TalTal/TalTal/Controllers/HistoryViewController.swift
@@ -8,93 +8,98 @@
 import UIKit
 
 class HistoryViewController: UIViewController {
-	
-	@IBOutlet var historyMainLabel: UILabel!
-	@IBOutlet var missioSegmentedControl: UISegmentedControl!
-	@IBOutlet weak var missionTableView: UITableView!
-	@IBOutlet weak var segmentedController: UISegmentedControl!
-	
-
-	// 코어데이터에서 저장된 데이터를 가져오는 모델
-	let missionDataManager = MissionDAO.shared
-	
-	// segmentedControl에 따른 다른 히스토리를 보여주기 위한 변수
-	var status: MissionQuest = .daily
-	
-	override func viewDidLoad() {
-		super.viewDidLoad()
-		missionTableView.delegate = self
-		missionTableView.dataSource = self
-	}
-	
-	// 화면에 진입할 때 마다 테이블뷰를 다시 그림
-	override func viewWillAppear(_ animated: Bool) {
-		super.viewWillAppear(animated)
-		missionTableView.reloadData()
-	}
-	
-	// segmentedControl에 따라서
-	// 1) 다른 히스토리를 보여주기
-	// 2) segmentedControl의 색 변경해주기
-	// 두 가지 일을 수행한 후 테이블뷰를 다시 그리기
-	@IBAction func switchMissionType(_ sender: UISegmentedControl) {
-		if sender.selectedSegmentIndex == 0 {
-			status = .daily // 1)
-			segmentedController.selectedSegmentTintColor = UIColor(named: "PointPink") // 2)
-			missionTableView.reloadData()
-		} else if sender.selectedSegmentIndex == 1 {
-			status = .weekly // 1)
-			segmentedController.selectedSegmentTintColor = UIColor(named: "PointBlue") // 2)
-			missionTableView.reloadData()
-		}
-	}
+    
+    
+    @IBOutlet var historyMainLabel: UILabel!
+    @IBOutlet var missioSegmentedControl: UISegmentedControl!
+    @IBOutlet weak var missionTableView: UITableView!
+    @IBOutlet weak var segmentedController: UISegmentedControl!
+    
+    //클리어한 미션이 하나도 없을 때 나오는 텍스트입니다.
+    @IBOutlet weak var nilClearMissionLabel: UILabel!
+    
+    
+    // 코어데이터에서 저장된 데이터를 가져오는 모델
+    let missionDataManager = MissionDAO.shared
+    
+    // segmentedControl에 따른 다른 히스토리를 보여주기 위한 변수
+    var status: MissionQuest = .daily
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        settingNilClearMissionLabelTextColor()
+        missionTableView.delegate = self
+        missionTableView.dataSource = self
+    }
+    
+    // 화면에 진입할 때 마다 테이블뷰를 다시 그림
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        missionTableView.reloadData()
+    }
+    
+    // segmentedControl에 따라서
+    // 1) 다른 히스토리를 보여주기
+    // 2) segmentedControl의 색 변경해주기
+    // 두 가지 일을 수행한 후 테이블뷰를 다시 그리기
+    @IBAction func switchMissionType(_ sender: UISegmentedControl) {
+        if sender.selectedSegmentIndex == 0 {
+            status = .daily // 1)
+            segmentedController.selectedSegmentTintColor = UIColor(named: "PointPink") // 2)
+            missionTableView.reloadData()
+        } else if sender.selectedSegmentIndex == 1 {
+            status = .weekly // 1)
+            segmentedController.selectedSegmentTintColor = UIColor(named: "PointBlue") // 2)
+            missionTableView.reloadData()
+        }
+    }
 }
 
 extension HistoryViewController: UITableViewDataSource {
-	
-	func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-
-		// 미션에 타입에 따라 미션 데이터의 갯수만큼 셀 생성
-		if status == .daily {
-			return MissionDataManager.shared.getCompleteMission(type: .daily).count
-		} else if status == .weekly {
-			return MissionDataManager.shared.getCompleteMission(type: .weekly).count
-		}
-		return 0
-	}
-	
-	func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-		
-		// 만들어진 셀을 꺼내서 사용
-		let cell = missionTableView.dequeueReusableCell(withIdentifier: "missionCell", for: indexPath) as! HistoryCell
-		
-		// 각 셀에 라운드 코너 주기
-		cell.cellView.layer.cornerRadius = 20
-		
-		if status == .daily {
-			cell.cellView.backgroundColor = UIColor(named: "PointLightPink")
-			cell.missionLabel.text = MissionDataManager.shared.getCompleteMission(type: .daily)[indexPath.row].content
-			cell.dateLabel.text = MissionDataManager.shared.getCompleteMission(type: .daily)[indexPath.row].clearDate?.timeToString()
-		} else if status == .weekly {
-			cell.cellView.backgroundColor = UIColor(named: "PointLightBlue")
-			cell.missionLabel.text = MissionDataManager.shared.getCompleteMission(type: .weekly)[indexPath.row].content
-			cell.dateLabel.text = MissionDataManager.shared.getCompleteMission(type: .weekly)[indexPath.row].clearDate?.timeToString()
-		}
-		return cell
-	}
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        
+        // 미션에 타입에 따라 미션 데이터의 갯수만큼 셀 생성
+        if status == .daily {
+            return settingNilClearMissionLabel(type: .daily)
+        } else if status == .weekly {
+            return settingNilClearMissionLabel(type: .weekly)
+        }
+        return 0
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        
+        // 만들어진 셀을 꺼내서 사용
+        let cell = missionTableView.dequeueReusableCell(withIdentifier: "missionCell", for: indexPath) as! HistoryCell
+        
+        // 각 셀에 라운드 코너 주기
+        cell.cellView.layer.cornerRadius = 20
+        
+        if status == .daily {
+            cell.cellView.backgroundColor = UIColor(named: "PointLightPink")
+            cell.missionLabel.text = MissionDataManager.shared.getCompleteMission(type: .daily)[indexPath.row].content
+            cell.dateLabel.text = MissionDataManager.shared.getCompleteMission(type: .daily)[indexPath.row].clearDate?.timeToString()
+        } else if status == .weekly {
+            cell.cellView.backgroundColor = UIColor(named: "PointLightBlue")
+            cell.missionLabel.text = MissionDataManager.shared.getCompleteMission(type: .weekly)[indexPath.row].content
+            cell.dateLabel.text = MissionDataManager.shared.getCompleteMission(type: .weekly)[indexPath.row].clearDate?.timeToString()
+        }
+        return cell
+    }
 }
 
 extension HistoryViewController: UITableViewDelegate {
-	
-	func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-		performSegue(withIdentifier: "toDetail", sender: indexPath)
-	}
-	
-	override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-		if segue.identifier == "toDetail" {
-			let reflectionViewController = segue.destination as! ReflectionViewController
-      
-			// getMissionData에서 미션을 받아옴
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        performSegue(withIdentifier: "toDetail", sender: indexPath)
+    }
+    
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        if segue.identifier == "toDetail" {
+            let reflectionViewController = segue.destination as! ReflectionViewController
+            
+            // getMissionData에서 미션을 받아옴
             switch status {
             case .daily:
                 let missionDatas = missionDataManager.fetchMissionData().filter { $0.type == .daily }
@@ -109,10 +114,30 @@ extension HistoryViewController: UITableViewDelegate {
                 reflectionViewController.missionData = missionDatas[indexPath.row]
                 print(missionDatas[indexPath.row])
             }
-			// Data 넘겨주는 코드
-			// ReflectionViewController에
-			// var missionData: Mission?
-			// 코드 추가 후 사용
-		}
-	}
+            // Data 넘겨주는 코드
+            // ReflectionViewController에
+            // var missionData: Mission?
+            // 코드 추가 후 사용
+        }
+    }
+}
+
+extension HistoryViewController{
+    //tableView(_:numberOfRowsInSection:)에서 셀이 나타나는 시점에
+    //생성되는 셀의 카운트를 가져와서 nilClearMissionLabel의 텍스트를 설정하고
+    //생성될 셀의 int 값을 반환합니다.
+    private func settingNilClearMissionLabel(type: MissionQuest) -> Int{
+        
+        if MissionDataManager.shared.getCompleteMission(type: type).count == 0 {
+            nilClearMissionLabel.text = "클리어한 미션이 없습니다."
+        }else{
+            nilClearMissionLabel.text = ""
+        }
+        return MissionDataManager.shared.getCompleteMission(type: type).count
+    }
+    
+    //nilClearMissionLabel의 텍스트 색상을 TextDarkGray로 바꿔주는 함수입니다.
+    private func settingNilClearMissionLabelTextColor(){
+        nilClearMissionLabel.textColor = UIColor(named: "TextDarkGray")
+    }
 }

--- a/TalTal/TalTal/StoryBoard/History.storyboard
+++ b/TalTal/TalTal/StoryBoard/History.storyboard
@@ -103,17 +103,27 @@
                                     </tableView>
                                 </subviews>
                             </stackView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xW9-bc-NP1" userLabel="nilClearMissionLabel">
+                                <rect key="frame" x="0.0" y="98.666666666666686" width="375" height="630.33333333333326"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="23"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="dXH-Tq-Ujw" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="16" id="3sb-ad-7Ey" userLabel="404TopLable Leading"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="xW9-bc-NP1" secondAttribute="trailing" id="BMo-XN-ocf"/>
                             <constraint firstItem="Jao-N8-my8" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="E3V-KP-oSq"/>
+                            <constraint firstItem="xW9-bc-NP1" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="I8E-k5-LlV"/>
                             <constraint firstItem="dXH-Tq-Ujw" firstAttribute="height" secondItem="vDu-zF-Fre" secondAttribute="height" multiplier="0.08" id="J2f-hY-Y3x" userLabel="404TopLable Height "/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="bottom" secondItem="Jao-N8-my8" secondAttribute="bottom" id="aVp-U0-uZT" userLabel="Stack View Bottom"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="dXH-Tq-Ujw" secondAttribute="trailing" constant="16" id="anI-2F-cUk" userLabel="404TopLabel Trailing"/>
                             <constraint firstItem="dXH-Tq-Ujw" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" id="gKR-54-cg8" userLabel="404TopLable Top"/>
                             <constraint firstItem="Jao-N8-my8" firstAttribute="width" secondItem="dXH-Tq-Ujw" secondAttribute="width" id="ktA-JG-jnh" userLabel="Stack View Width"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="bottom" secondItem="xW9-bc-NP1" secondAttribute="bottom" id="tjp-Zw-8UA"/>
+                            <constraint firstItem="xW9-bc-NP1" firstAttribute="top" secondItem="dXH-Tq-Ujw" secondAttribute="bottom" id="vSq-wX-0S7"/>
                             <constraint firstItem="Jao-N8-my8" firstAttribute="top" secondItem="dXH-Tq-Ujw" secondAttribute="bottom" id="yUh-X3-7He" userLabel="Stack View Top"/>
                         </constraints>
                     </view>
@@ -123,6 +133,7 @@
                         <outlet property="historyMainLabel" destination="2DG-cM-HgV" id="7mE-Z1-QKF"/>
                         <outlet property="missioSegmentedControl" destination="ege-A2-Oop" id="QLw-Ax-JMb"/>
                         <outlet property="missionTableView" destination="TMn-Q6-S1c" id="kHm-bo-AnS"/>
+                        <outlet property="nilClearMissionLabel" destination="xW9-bc-NP1" id="E0n-pt-GIY"/>
                         <outlet property="segmentedController" destination="ege-A2-Oop" id="Zka-3Y-69G"/>
                         <segue destination="9Ek-6Z-lIh" kind="presentation" identifier="toDetail" id="ZW3-bb-cCt"/>
                     </connections>


### PR DESCRIPTION
## 개요
히스토리뷰 완료 미션이 없을 때, 알림문구 뷰잉 및 런치스크린 이미지 크기 수정

## 작업사항
1.  히스토리뷰 완료 미션이 없을 때, 알림문구 뷰잉
<img src="https://user-images.githubusercontent.com/102962238/182578258-741387f8-f113-427c-903c-b4297151b4b4.png" width="300">

2. 런치스크린 이미지 크기 수정
<img src="https://user-images.githubusercontent.com/102962238/182578196-2ed43e03-c191-44e6-ba0e-86eca0a2d8af.png" width="300">

## 변경 혹은 추가 사항 설명
핫픽스에 머지 하겠습니다.

